### PR TITLE
add jitpack configuration file

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Now the build does not fail anymore on jitpack and it is possible to reference the artefact in maven or gradle.